### PR TITLE
Support multi-car in real cars with updated namespace.

### DIFF
--- a/vesc_driver/src/throttle_interpolator.py
+++ b/vesc_driver/src/throttle_interpolator.py
@@ -57,14 +57,14 @@ class InterpolateThrottle:
         rospy.spin()
 
     def _publish_throttle_command(self, evt):
-        desired_delta = self.desired_rpm-self.last_rpm
+        desired_delta = self.desired_rpm - self.last_rpm
         clipped_delta = max(min(desired_delta, self.max_delta_rpm), -self.max_delta_rpm)
         smoothed_rpm = self.last_rpm + clipped_delta
         self.last_rpm = smoothed_rpm
         # print self.desired_rpm, smoothed_rpm
         self.rpm_output.publish(Float64(smoothed_rpm))
 
-    def _process_throttle_command(self,msg):
+    def _process_throttle_command(self, msg):
         input_rpm = msg.data
         # Do some sanity clipping
         input_rpm = min(max(input_rpm, self.min_rpm), self.max_rpm)

--- a/vesc_driver/src/throttle_interpolator.py
+++ b/vesc_driver/src/throttle_interpolator.py
@@ -25,32 +25,30 @@ class InterpolateThrottle:
             "~servo_output_topic", "{}/vesc/commands/servo/position".format(car_name)
         )
 
-        self.max_acceleration = rospy.get_param(
-            "{}/vesc/max_acceleration".format(car_name)
-        )
-        self.max_rpm = rospy.get_param("{}/vesc/vesc_driver/speed_max".format(car_name))
-        self.min_rpm = rospy.get_param("{}/vesc/vesc_driver/speed_min".format(car_name))
+        self.max_acceleration = rospy.get_param(rospy.search_param("max_acceleration"))
+        self.max_rpm = rospy.get_param(rospy.search_param("vesc_driver/speed_max"))
+        self.min_rpm = rospy.get_param(rospy.search_param("vesc_driver/speed_min"))
         self.throttle_smoother_rate = rospy.get_param(
-            "{}/vesc/throttle_smoother_rate".format(car_name)
+            rospy.search_param("throttle_smoother_rate")
         )
         self.speed_to_erpm_gain = rospy.get_param(
-            "{}/vesc/speed_to_erpm_gain".format(car_name)
+            rospy.search_param("speed_to_erpm_gain")
         )
 
         self.max_servo_speed = rospy.get_param(
-            "{}/vesc/max_servo_speed".format(car_name)
+            rospy.search_param("max_servo_speed")
         )
         self.steering_angle_to_servo_gain = rospy.get_param(
-            "{}/vesc/steering_angle_to_servo_gain".format(car_name)
+            rospy.search_param("steering_angle_to_servo_gain")
         )
         self.servo_smoother_rate = rospy.get_param(
-            "{}/vesc/servo_smoother_rate".format(car_name)
+            rospy.search_param("servo_smoother_rate")
         )
         self.max_servo = rospy.get_param(
-            "{}/vesc/vesc_driver/servo_max".format(car_name)
+            rospy.search_param("vesc_driver/servo_max")
         )
         self.min_servo = rospy.get_param(
-            "{}/vesc/vesc_driver/servo_min".format(car_name)
+            rospy.search_param("vesc_driver/servo_min")
         )
 
         # Variables
@@ -58,7 +56,7 @@ class InterpolateThrottle:
         self.desired_rpm = self.last_rpm
 
         self.last_servo = rospy.get_param(
-            "{}/vesc/steering_angle_to_servo_offset".format(car_name)
+            rospy.search_param("steering_angle_to_servo_offset")
         )
         self.desired_servo_position = self.last_servo
 

--- a/vesc_driver/src/throttle_interpolator.py
+++ b/vesc_driver/src/throttle_interpolator.py
@@ -127,7 +127,7 @@ if __name__ == '__main__':
     car_name = "" if len(sys.argv) < 2 else sys.argv[1]
 
     try:
-        rospy.init_node('Throttle_Interpolator')
+        rospy.init_node("Throttle_Interpolator")
         p = InterpolateThrottle(car_name=car_name)
     except rospy.ROSInterruptException:
         pass

--- a/vesc_driver/src/throttle_interpolator.py
+++ b/vesc_driver/src/throttle_interpolator.py
@@ -35,21 +35,15 @@ class InterpolateThrottle:
             rospy.search_param("speed_to_erpm_gain")
         )
 
-        self.max_servo_speed = rospy.get_param(
-            rospy.search_param("max_servo_speed")
-        )
+        self.max_servo_speed = rospy.get_param(rospy.search_param("max_servo_speed"))
         self.steering_angle_to_servo_gain = rospy.get_param(
             rospy.search_param("steering_angle_to_servo_gain")
         )
         self.servo_smoother_rate = rospy.get_param(
             rospy.search_param("servo_smoother_rate")
         )
-        self.max_servo = rospy.get_param(
-            rospy.search_param("vesc_driver/servo_max")
-        )
-        self.min_servo = rospy.get_param(
-            rospy.search_param("vesc_driver/servo_min")
-        )
+        self.max_servo = rospy.get_param(rospy.search_param("vesc_driver/servo_max"))
+        self.min_servo = rospy.get_param(rospy.search_param("vesc_driver/servo_min"))
 
         # Variables
         self.last_rpm = 0

--- a/vesc_driver/src/throttle_interpolator.py
+++ b/vesc_driver/src/throttle_interpolator.py
@@ -8,32 +8,32 @@ import numpy as np
 import copy as copy
 
 class InterpolateThrottle:
-    def __init__(self):
+    def __init__(self, car_name):
 
         # Allow our topics to be dynamic.
-        self.rpm_input_topic   = rospy.get_param('~rpm_input_topic', '/vesc/commands/motor/unsmoothed_speed')
-        self.rpm_output_topic  = rospy.get_param('~rpm_output_topic', '/vesc/commands/motor/speed')
+        self.rpm_input_topic   = rospy.get_param('~rpm_input_topic', '{}/vesc/commands/motor/unsmoothed_speed'.format(car_name))
+        self.rpm_output_topic  = rospy.get_param('~rpm_output_topic', '{}/vesc/commands/motor/speed'.format(car_name))
 
-        self.servo_input_topic   = rospy.get_param('~servo_input_topic', '/vesc/commands/servo/unsmoothed_position')
-        self.servo_output_topic  = rospy.get_param('~servo_output_topic', '/vesc/commands/servo/position')
+        self.servo_input_topic   = rospy.get_param('~servo_input_topic', '{}/vesc/commands/servo/unsmoothed_position'.format(car_name))
+        self.servo_output_topic  = rospy.get_param('~servo_output_topic', '{}/vesc/commands/servo/position'.format(car_name))
 
-        self.max_acceleration = rospy.get_param('/vesc/max_acceleration')
-        self.max_rpm = rospy.get_param('/vesc/vesc_driver/speed_max')
-        self.min_rpm = rospy.get_param('/vesc/vesc_driver/speed_min')
-        self.throttle_smoother_rate = rospy.get_param('/vesc/throttle_smoother_rate')
-        self.speed_to_erpm_gain = rospy.get_param('/vesc/speed_to_erpm_gain')
+        self.max_acceleration = rospy.get_param('{}/vesc/max_acceleration'.format(car_name))
+        self.max_rpm = rospy.get_param('{}/vesc/vesc_driver/speed_max'.format(car_name))
+        self.min_rpm = rospy.get_param('{}/vesc/vesc_driver/speed_min'.format(car_name))
+        self.throttle_smoother_rate = rospy.get_param('{}/vesc/throttle_smoother_rate'.format(car_name))
+        self.speed_to_erpm_gain = rospy.get_param('{}/vesc/speed_to_erpm_gain'.format(car_name))
 
-        self.max_servo_speed = rospy.get_param('/vesc/max_servo_speed')
-        self.steering_angle_to_servo_gain = rospy.get_param('/vesc/steering_angle_to_servo_gain')
-        self.servo_smoother_rate = rospy.get_param('/vesc/servo_smoother_rate')
-        self.max_servo = rospy.get_param('/vesc/vesc_driver/servo_max')
-        self.min_servo = rospy.get_param('/vesc/vesc_driver/servo_min')
+        self.max_servo_speed = rospy.get_param('{}/vesc/max_servo_speed'.format(car_name))
+        self.steering_angle_to_servo_gain = rospy.get_param('{}/vesc/steering_angle_to_servo_gain'.format(car_name))
+        self.servo_smoother_rate = rospy.get_param('{}/vesc/servo_smoother_rate'.format(car_name))
+        self.max_servo = rospy.get_param('{}/vesc/vesc_driver/servo_max'.format(car_name))
+        self.min_servo = rospy.get_param('{}/vesc/vesc_driver/servo_min'.format(car_name))
 
         # Variables
         self.last_rpm = 0
         self.desired_rpm = self.last_rpm
 
-        self.last_servo = rospy.get_param('/vesc/steering_angle_to_servo_offset')
+        self.last_servo = rospy.get_param('{}/vesc/steering_angle_to_servo_offset'.format(car_name))
         self.desired_servo_position = self.last_servo
 
         # Create topic subscribers and publishers
@@ -86,8 +86,11 @@ class InterpolateThrottle:
 
 # Boilerplate node spin up.
 if __name__ == '__main__':
+    import sys
+    car_name = "" if len(sys.argv) < 2 else sys.argv[1]
+
     try:
         rospy.init_node('Throttle_Interpolator')
-        p = InterpolateThrottle()
+        p = InterpolateThrottle(car_name=car_name)
     except rospy.ROSInterruptException:
         pass

--- a/vesc_driver/src/throttle_interpolator.py
+++ b/vesc_driver/src/throttle_interpolator.py
@@ -7,119 +7,82 @@ from std_msgs.msg import Float64
 import numpy as np
 import copy as copy
 
-
 class InterpolateThrottle:
     def __init__(self, car_name):
 
         # Allow our topics to be dynamic.
-        self.rpm_input_topic = rospy.get_param(
-            "~rpm_input_topic", "{}/commands/motor/unsmoothed_speed".format(car_name)
-        )
-        self.rpm_output_topic = rospy.get_param(
-            "~rpm_output_topic", "{}/commands/motor/speed".format(car_name)
-        )
+        self.rpm_input_topic   = rospy.get_param('~rpm_input_topic', '{}/vesc/commands/motor/unsmoothed_speed'.format(car_name))
+        self.rpm_output_topic  = rospy.get_param('~rpm_output_topic', '{}/vesc/commands/motor/speed'.format(car_name))
 
-        self.servo_input_topic = rospy.get_param(
-            "~servo_input_topic", "{}/commands/servo/unsmoothed_position".format(car_name)
-        )
-        self.servo_output_topic = rospy.get_param(
-            "~servo_output_topic", "{}/commands/servo/position".format(car_name)
-        )
+        self.servo_input_topic   = rospy.get_param('~servo_input_topic', '{}/vesc/commands/servo/unsmoothed_position'.format(car_name))
+        self.servo_output_topic  = rospy.get_param('~servo_output_topic', '{}/vesc/commands/servo/position'.format(car_name))
 
-        self.max_acceleration = rospy.get_param(rospy.search_param("{}/max_acceleration".format(car_name)))
-        self.max_rpm = rospy.get_param(rospy.search_param("{}/vesc_driver/speed_max".format(car_name)))
-        self.min_rpm = rospy.get_param(rospy.search_param("{}/vesc_driver/speed_min".format(car_name)))
-        self.throttle_smoother_rate = rospy.get_param(
-            rospy.search_param("{}/throttle_smoother_rate".format(car_name))
-        )
-        self.speed_to_erpm_gain = rospy.get_param(
-            rospy.search_param("{}/speed_to_erpm_gain".format(car_name))
-        )
+        self.max_acceleration = rospy.get_param('{}/vesc/max_acceleration'.format(car_name))
+        self.max_rpm = rospy.get_param('{}/vesc/vesc_driver/speed_max'.format(car_name))
+        self.min_rpm = rospy.get_param('{}/vesc/vesc_driver/speed_min'.format(car_name))
+        self.throttle_smoother_rate = rospy.get_param('{}/vesc/throttle_smoother_rate'.format(car_name))
+        self.speed_to_erpm_gain = rospy.get_param('{}/vesc/speed_to_erpm_gain'.format(car_name))
 
-        self.max_servo_speed = rospy.get_param(rospy.search_param("{}/max_servo_speed".format(car_name)))
-        self.steering_angle_to_servo_gain = rospy.get_param(
-            rospy.search_param("{}/steering_angle_to_servo_gain".format(car_name))
-        )
-        self.servo_smoother_rate = rospy.get_param(
-            rospy.search_param("{}/servo_smoother_rate".format(car_name))
-        )
-        self.max_servo = rospy.get_param(rospy.search_param("{}/vesc_driver/servo_max".format(car_name)))
-        self.min_servo = rospy.get_param(rospy.search_param("{}/vesc_driver/servo_min".format(car_name)))
+        self.max_servo_speed = rospy.get_param('{}/vesc/max_servo_speed'.format(car_name))
+        self.steering_angle_to_servo_gain = rospy.get_param('{}/vesc/steering_angle_to_servo_gain'.format(car_name))
+        self.servo_smoother_rate = rospy.get_param('{}/vesc/servo_smoother_rate'.format(car_name))
+        self.max_servo = rospy.get_param('{}/vesc/vesc_driver/servo_max'.format(car_name))
+        self.min_servo = rospy.get_param('{}/vesc/vesc_driver/servo_min'.format(car_name))
 
         # Variables
         self.last_rpm = 0
         self.desired_rpm = self.last_rpm
 
-        self.last_servo = rospy.get_param(
-            rospy.search_param("{}/steering_angle_to_servo_offset".format(car_name))
-        )
+        self.last_servo = rospy.get_param('{}/vesc/steering_angle_to_servo_offset'.format(car_name))
         self.desired_servo_position = self.last_servo
 
         # Create topic subscribers and publishers
-        self.rpm_output = rospy.Publisher(self.rpm_output_topic, Float64, queue_size=1)
-        self.servo_output = rospy.Publisher(
-            self.servo_output_topic, Float64, queue_size=1
-        )
+        self.rpm_output = rospy.Publisher(self.rpm_output_topic, Float64,queue_size=1)
+        self.servo_output = rospy.Publisher(self.servo_output_topic, Float64,queue_size=1)
 
         rospy.Subscriber(self.rpm_input_topic, Float64, self._process_throttle_command)
         rospy.Subscriber(self.servo_input_topic, Float64, self._process_servo_command)
 
-        self.max_delta_servo = abs(
-            self.steering_angle_to_servo_gain
-            * self.max_servo_speed
-            / self.servo_smoother_rate
-        )
-        rospy.Timer(
-            rospy.Duration(1.0 / self.servo_smoother_rate), self._publish_servo_command
-        )
+        self.max_delta_servo = abs(self.steering_angle_to_servo_gain * self.max_servo_speed / self.servo_smoother_rate)
+        rospy.Timer(rospy.Duration(1.0/self.servo_smoother_rate), self._publish_servo_command)
 
-        self.max_delta_rpm = abs(
-            self.speed_to_erpm_gain
-            * self.max_acceleration
-            / self.throttle_smoother_rate
-        )
-        rospy.Timer(
-            rospy.Duration(1.0 / self.max_delta_rpm), self._publish_throttle_command
-        )
+        self.max_delta_rpm = abs(self.speed_to_erpm_gain * self.max_acceleration / self.throttle_smoother_rate)
+        rospy.Timer(rospy.Duration(1.0/self.max_delta_rpm), self._publish_throttle_command)
 
         # run the node
         self._run()
 
         # Keep the node alive
-
     def _run(self):
         rospy.spin()
 
     def _publish_throttle_command(self, evt):
-        desired_delta = self.desired_rpm - self.last_rpm
+        desired_delta = self.desired_rpm-self.last_rpm
         clipped_delta = max(min(desired_delta, self.max_delta_rpm), -self.max_delta_rpm)
         smoothed_rpm = self.last_rpm + clipped_delta
         self.last_rpm = smoothed_rpm
         # print self.desired_rpm, smoothed_rpm
         self.rpm_output.publish(Float64(smoothed_rpm))
 
-    def _process_throttle_command(self, msg):
+    def _process_throttle_command(self,msg):
         input_rpm = msg.data
         # Do some sanity clipping
         input_rpm = min(max(input_rpm, self.min_rpm), self.max_rpm)
         self.desired_rpm = input_rpm
 
     def _publish_servo_command(self, evt):
-        desired_delta = self.desired_servo_position - self.last_servo
-        clipped_delta = max(
-            min(desired_delta, self.max_delta_servo), -self.max_delta_servo
-        )
+        desired_delta = self.desired_servo_position-self.last_servo
+        clipped_delta = max(min(desired_delta, self.max_delta_servo), -self.max_delta_servo)
         smoothed_servo = self.last_servo + clipped_delta
         self.last_servo = smoothed_servo
         self.servo_output.publish(Float64(smoothed_servo))
 
-    def _process_servo_command(self, msg):
+    def _process_servo_command(self,msg):
         input_servo = msg.data
         # Do some sanity clipping
         input_servo = min(max(input_servo, self.min_servo), self.max_servo)
         # set the target servo position
         self.desired_servo_position = input_servo
-
 
 # Boilerplate node spin up.
 if __name__ == '__main__':
@@ -127,7 +90,7 @@ if __name__ == '__main__':
     car_name = "" if len(sys.argv) < 2 else sys.argv[1]
 
     try:
-        rospy.init_node("Throttle_Interpolator")
+        rospy.init_node('Throttle_Interpolator')
         p = InterpolateThrottle(car_name=car_name)
     except rospy.ROSInterruptException:
         pass

--- a/vesc_driver/src/throttle_interpolator.py
+++ b/vesc_driver/src/throttle_interpolator.py
@@ -27,7 +27,7 @@ class InterpolateThrottle:
         )
 
         self.max_acceleration = rospy.get_param(rospy.search_param("{}/max_acceleration".format(car_name)))
-        self.max_rpm = rospy.get_param(rospy.search_param("{}/vesc_driver/speed_max".format(car_name))
+        self.max_rpm = rospy.get_param(rospy.search_param("{}/vesc_driver/speed_max".format(car_name)))
         self.min_rpm = rospy.get_param(rospy.search_param("{}/vesc_driver/speed_min".format(car_name)))
         self.throttle_smoother_rate = rospy.get_param(
             rospy.search_param("{}/throttle_smoother_rate".format(car_name))

--- a/vesc_driver/src/throttle_interpolator.py
+++ b/vesc_driver/src/throttle_interpolator.py
@@ -6,7 +6,8 @@ from std_msgs.msg import Float64
 
 
 class InterpolateThrottle:
-    def __init__(self, car_name):
+    def __init__(self):
+        car_name = rospy.get_param("~car_name", "/car")
 
         # Allow our topics to be dynamic.
         self.rpm_input_topic = rospy.get_param(
@@ -122,12 +123,8 @@ class InterpolateThrottle:
 
 # Boilerplate node spin up.
 if __name__ == "__main__":
-    import sys
-
-    car_name = "/car" if len(sys.argv) < 2 else sys.argv[1]
-
     try:
         rospy.init_node("Throttle_Interpolator")
-        p = InterpolateThrottle(car_name=car_name)
+        p = InterpolateThrottle()
     except rospy.ROSInterruptException:
         pass

--- a/vesc_driver/src/throttle_interpolator.py
+++ b/vesc_driver/src/throttle_interpolator.py
@@ -26,9 +26,9 @@ class InterpolateThrottle:
             "~servo_output_topic", "{}/commands/servo/position".format(car_name)
         )
 
-        self.max_acceleration = rospy.get_param(rospy.search_param("{}/max_acceleration").format(car_name))
-        self.max_rpm = rospy.get_param(rospy.search_param("{}/vesc_driver/speed_max").format(car_name))
-        self.min_rpm = rospy.get_param(rospy.search_param("{}/vesc_driver/speed_min").format(car_name))
+        self.max_acceleration = rospy.get_param(rospy.search_param("{}/max_acceleration".format(car_name)))
+        self.max_rpm = rospy.get_param(rospy.search_param("{}/vesc_driver/speed_max".format(car_name))
+        self.min_rpm = rospy.get_param(rospy.search_param("{}/vesc_driver/speed_min".format(car_name)))
         self.throttle_smoother_rate = rospy.get_param(
             rospy.search_param("{}/throttle_smoother_rate".format(car_name))
         )
@@ -43,8 +43,8 @@ class InterpolateThrottle:
         self.servo_smoother_rate = rospy.get_param(
             rospy.search_param("{}/servo_smoother_rate".format(car_name))
         )
-        self.max_servo = rospy.get_param(rospy.search_param("{}/vesc_driver/servo_max").format(car_name))
-        self.min_servo = rospy.get_param(rospy.search_param("{}/vesc_driver/servo_min").format(car_name))
+        self.max_servo = rospy.get_param(rospy.search_param("{}/vesc_driver/servo_max".format(car_name)))
+        self.min_servo = rospy.get_param(rospy.search_param("{}/vesc_driver/servo_min".format(car_name)))
 
         # Variables
         self.last_rpm = 0

--- a/vesc_driver/src/throttle_interpolator.py
+++ b/vesc_driver/src/throttle_interpolator.py
@@ -1,58 +1,99 @@
 #!/usr/bin/env python
-import rospy
-
-from std_msgs.msg import Float64
 
 # import some utils.
-import numpy as np
-import copy as copy
+import rospy
+from std_msgs.msg import Float64
+
 
 class InterpolateThrottle:
     def __init__(self, car_name):
 
         # Allow our topics to be dynamic.
-        self.rpm_input_topic   = rospy.get_param('~rpm_input_topic', '{}/vesc/commands/motor/unsmoothed_speed'.format(car_name))
-        self.rpm_output_topic  = rospy.get_param('~rpm_output_topic', '{}/vesc/commands/motor/speed'.format(car_name))
+        self.rpm_input_topic = rospy.get_param(
+            "~rpm_input_topic",
+            "{}/vesc/commands/motor/unsmoothed_speed".format(car_name),
+        )
+        self.rpm_output_topic = rospy.get_param(
+            "~rpm_output_topic", "{}/vesc/commands/motor/speed".format(car_name)
+        )
 
-        self.servo_input_topic   = rospy.get_param('~servo_input_topic', '{}/vesc/commands/servo/unsmoothed_position'.format(car_name))
-        self.servo_output_topic  = rospy.get_param('~servo_output_topic', '{}/vesc/commands/servo/position'.format(car_name))
+        self.servo_input_topic = rospy.get_param(
+            "~servo_input_topic",
+            "{}/vesc/commands/servo/unsmoothed_position".format(car_name),
+        )
+        self.servo_output_topic = rospy.get_param(
+            "~servo_output_topic", "{}/vesc/commands/servo/position".format(car_name)
+        )
 
-        self.max_acceleration = rospy.get_param('{}/vesc/max_acceleration'.format(car_name))
-        self.max_rpm = rospy.get_param('{}/vesc/vesc_driver/speed_max'.format(car_name))
-        self.min_rpm = rospy.get_param('{}/vesc/vesc_driver/speed_min'.format(car_name))
-        self.throttle_smoother_rate = rospy.get_param('{}/vesc/throttle_smoother_rate'.format(car_name))
-        self.speed_to_erpm_gain = rospy.get_param('{}/vesc/speed_to_erpm_gain'.format(car_name))
+        self.max_acceleration = rospy.get_param(
+            "{}/vesc/max_acceleration".format(car_name)
+        )
+        self.max_rpm = rospy.get_param("{}/vesc/vesc_driver/speed_max".format(car_name))
+        self.min_rpm = rospy.get_param("{}/vesc/vesc_driver/speed_min".format(car_name))
+        self.throttle_smoother_rate = rospy.get_param(
+            "{}/vesc/throttle_smoother_rate".format(car_name)
+        )
+        self.speed_to_erpm_gain = rospy.get_param(
+            "{}/vesc/speed_to_erpm_gain".format(car_name)
+        )
 
-        self.max_servo_speed = rospy.get_param('{}/vesc/max_servo_speed'.format(car_name))
-        self.steering_angle_to_servo_gain = rospy.get_param('{}/vesc/steering_angle_to_servo_gain'.format(car_name))
-        self.servo_smoother_rate = rospy.get_param('{}/vesc/servo_smoother_rate'.format(car_name))
-        self.max_servo = rospy.get_param('{}/vesc/vesc_driver/servo_max'.format(car_name))
-        self.min_servo = rospy.get_param('{}/vesc/vesc_driver/servo_min'.format(car_name))
+        self.max_servo_speed = rospy.get_param(
+            "{}/vesc/max_servo_speed".format(car_name)
+        )
+        self.steering_angle_to_servo_gain = rospy.get_param(
+            "{}/vesc/steering_angle_to_servo_gain".format(car_name)
+        )
+        self.servo_smoother_rate = rospy.get_param(
+            "{}/vesc/servo_smoother_rate".format(car_name)
+        )
+        self.max_servo = rospy.get_param(
+            "{}/vesc/vesc_driver/servo_max".format(car_name)
+        )
+        self.min_servo = rospy.get_param(
+            "{}/vesc/vesc_driver/servo_min".format(car_name)
+        )
 
         # Variables
         self.last_rpm = 0
         self.desired_rpm = self.last_rpm
 
-        self.last_servo = rospy.get_param('{}/vesc/steering_angle_to_servo_offset'.format(car_name))
+        self.last_servo = rospy.get_param(
+            "{}/vesc/steering_angle_to_servo_offset".format(car_name)
+        )
         self.desired_servo_position = self.last_servo
 
         # Create topic subscribers and publishers
-        self.rpm_output = rospy.Publisher(self.rpm_output_topic, Float64,queue_size=1)
-        self.servo_output = rospy.Publisher(self.servo_output_topic, Float64,queue_size=1)
+        self.rpm_output = rospy.Publisher(self.rpm_output_topic, Float64, queue_size=1)
+        self.servo_output = rospy.Publisher(
+            self.servo_output_topic, Float64, queue_size=1
+        )
 
         rospy.Subscriber(self.rpm_input_topic, Float64, self._process_throttle_command)
         rospy.Subscriber(self.servo_input_topic, Float64, self._process_servo_command)
 
-        self.max_delta_servo = abs(self.steering_angle_to_servo_gain * self.max_servo_speed / self.servo_smoother_rate)
-        rospy.Timer(rospy.Duration(1.0/self.servo_smoother_rate), self._publish_servo_command)
+        self.max_delta_servo = abs(
+            self.steering_angle_to_servo_gain
+            * self.max_servo_speed
+            / self.servo_smoother_rate
+        )
+        rospy.Timer(
+            rospy.Duration(1.0 / self.servo_smoother_rate), self._publish_servo_command
+        )
 
-        self.max_delta_rpm = abs(self.speed_to_erpm_gain * self.max_acceleration / self.throttle_smoother_rate)
-        rospy.Timer(rospy.Duration(1.0/self.max_delta_rpm), self._publish_throttle_command)
+        self.max_delta_rpm = abs(
+            self.speed_to_erpm_gain
+            * self.max_acceleration
+            / self.throttle_smoother_rate
+        )
+        rospy.Timer(
+            rospy.Duration(1.0 / self.max_delta_rpm), self._publish_throttle_command
+        )
 
         # run the node
         self._run()
 
         # Keep the node alive
+
     def _run(self):
         rospy.spin()
 
@@ -71,26 +112,30 @@ class InterpolateThrottle:
         self.desired_rpm = input_rpm
 
     def _publish_servo_command(self, evt):
-        desired_delta = self.desired_servo_position-self.last_servo
-        clipped_delta = max(min(desired_delta, self.max_delta_servo), -self.max_delta_servo)
+        desired_delta = self.desired_servo_position - self.last_servo
+        clipped_delta = max(
+            min(desired_delta, self.max_delta_servo), -self.max_delta_servo
+        )
         smoothed_servo = self.last_servo + clipped_delta
         self.last_servo = smoothed_servo
         self.servo_output.publish(Float64(smoothed_servo))
 
-    def _process_servo_command(self,msg):
+    def _process_servo_command(self, msg):
         input_servo = msg.data
         # Do some sanity clipping
         input_servo = min(max(input_servo, self.min_servo), self.max_servo)
         # set the target servo position
         self.desired_servo_position = input_servo
 
+
 # Boilerplate node spin up.
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
-    car_name = "" if len(sys.argv) < 2 else sys.argv[1]
+
+    car_name = "/car" if len(sys.argv) < 2 else sys.argv[1]
 
     try:
-        rospy.init_node('Throttle_Interpolator')
+        rospy.init_node("Throttle_Interpolator")
         p = InterpolateThrottle(car_name=car_name)
     except rospy.ROSInterruptException:
         pass

--- a/vesc_main/launch/vesc.launch
+++ b/vesc_main/launch/vesc.launch
@@ -3,11 +3,13 @@
     <arg name="racecar_version" />
     <arg name="vesc_config" default="$(find vesc_main)/config/$(arg racecar_version)/vesc.yaml" />
 
+    <arg name="car_name" default="car" />
+
     <rosparam file="$(arg vesc_config)" command="load" />
 
     <node pkg="vesc_ackermann" type="ackermann_to_vesc_node" name="ackermann_to_vesc">
         <!-- Remap to make mux control work with the VESC -->
-        <remap from="ackermann_cmd" to="/mux/ackermann_cmd_mux/output" />
+        <remap from="ackermann_cmd" to="/$(arg car_name)/mux/ackermann_cmd_mux/output" />
 
         <!-- Remap to make vesc have trapezoidal control on the throttle to avoid skipping -->
         <remap from="commands/motor/speed" to="commands/motor/unsmoothed_speed" />

--- a/vesc_main/launch/vesc.launch
+++ b/vesc_main/launch/vesc.launch
@@ -3,7 +3,7 @@
     <arg name="racecar_version" />
     <arg name="vesc_config" default="$(find vesc_main)/config/$(arg racecar_version)/vesc.yaml" />
 
-    <arg name="car_name" default="car" />
+    <arg name="car_name"/>
 
     <rosparam file="$(arg vesc_config)" command="load" />
 
@@ -18,7 +18,7 @@
         <remap from="commands/servo/position" to="commands/servo/unsmoothed_position" />
     </node>
 
-    <node pkg="vesc_driver" type="throttle_interpolator.py" name="throttle_interpolator"  />
+    <node pkg="vesc_driver" type="throttle_interpolator.py" name="throttle_interpolator" args="$(arg car_name)"/>
     <node pkg="vesc_driver" type="vesc_driver_node" name="vesc_driver" respawn="true"/>
     <node pkg="vesc_ackermann" type="vesc_to_odom_node" name="vesc_to_odom"/>
 </launch>

--- a/vesc_main/launch/vesc.launch
+++ b/vesc_main/launch/vesc.launch
@@ -18,7 +18,9 @@
         <remap from="commands/servo/position" to="commands/servo/unsmoothed_position" />
     </node>
 
-    <node pkg="vesc_driver" type="throttle_interpolator.py" name="throttle_interpolator" args="$(arg car_name)" />
+    <node pkg="vesc_driver" type="throttle_interpolator.py" name="throttle_interpolator">
+        <param name="car_name" value="$(arg car_name)" />
+    </node>
     <node pkg="vesc_driver" type="vesc_driver_node" name="vesc_driver" respawn="true"/>
     <node pkg="vesc_ackermann" type="vesc_to_odom_node" name="vesc_to_odom"/>
 </launch>

--- a/vesc_main/launch/vesc.launch
+++ b/vesc_main/launch/vesc.launch
@@ -3,7 +3,7 @@
     <arg name="racecar_version" />
     <arg name="vesc_config" default="$(find vesc_main)/config/$(arg racecar_version)/vesc.yaml" />
 
-    <arg name="car_name"/>
+    <arg name="car_name" default="car" />
 
     <rosparam file="$(arg vesc_config)" command="load" />
 

--- a/vesc_main/launch/vesc.launch
+++ b/vesc_main/launch/vesc.launch
@@ -18,7 +18,7 @@
         <remap from="commands/servo/position" to="commands/servo/unsmoothed_position" />
     </node>
 
-    <node pkg="vesc_driver" type="throttle_interpolator.py" name="throttle_interpolator" args="$(arg car_name)"/>
+    <node pkg="vesc_driver" type="throttle_interpolator.py" name="throttle_interpolator" args="$(arg car_name)" />
     <node pkg="vesc_driver" type="vesc_driver_node" name="vesc_driver" respawn="true"/>
     <node pkg="vesc_ackermann" type="vesc_to_odom_node" name="vesc_to_odom"/>
 </launch>


### PR DESCRIPTION
This PR enables multi-car control by updating vesc to operate under car_name namespace. This PR is to be merged in conjunction with other PRs in prl-mushr/mushr#6 and prl-mushr/mushr_base#6

It now expects all mux and vesc commands to be under car_name namespace, e.g.
```
/car30/mux/ackermann_cmd_mux/active
...
/car30/vesc/commands/motor/brake
...
/dev/null
```
