### PR TITLE
Fix odometry calculation of angular velocity

### DIFF
--- a/vesc_ackermann/include/vesc_ackermann/vesc_to_odom.h
+++ b/vesc_ackermann/include/vesc_ackermann/vesc_to_odom.h
@@ -27,7 +27,7 @@ private:
   // conversion gain and offset
   double speed_to_erpm_gain_, speed_to_erpm_offset_;
   double steering_to_servo_gain_, steering_to_servo_offset_;
-  double wheelbase_;
+  double chassis_length_;
   bool publish_tf_;
 
   // odometry state

--- a/vesc_ackermann/src/vesc_to_odom.cpp
+++ b/vesc_ackermann/src/vesc_to_odom.cpp
@@ -30,7 +30,7 @@ VescToOdom::VescToOdom(ros::NodeHandle nh, ros::NodeHandle private_nh) :
       return;
     if (!getRequiredParam(nh, "steering_angle_to_servo_offset", steering_to_servo_offset_))
       return;
-    if (!getRequiredParam(nh, "wheelbase", wheelbase_))
+    if (!getRequiredParam(nh, "chassis_length", chassis_length_))
       return;
   }
   private_nh.param("publish_tf", publish_tf_, publish_tf_);
@@ -63,7 +63,7 @@ void VescToOdom::vescStateCallback(const vesc_msgs::VescStateStamped::ConstPtr& 
   if (use_servo_cmd_) {
     current_steering_angle =
       ( last_servo_cmd_->data - steering_to_servo_offset_ ) / steering_to_servo_gain_;
-    current_angular_velocity = current_speed * tan(current_steering_angle) / wheelbase_;
+    current_angular_velocity = current_speed * tan(current_steering_angle) / chassis_length_;
   }
 
   // use current state as last state if this is our first time here


### PR DESCRIPTION
Fixes odometry calculations for `current_angular_velocity`, which is incorrectly calculated using the car width (`wheelbase`) instead of the car length (`chassis_length`).

Note that technically 'wheelbase' _does_ mean 'car length', but it's not defined or used that way, and would otherwise be completely redundant with `chassis_length`. In`vesc.yaml`, the value for `wheelbase` is roughly equal to the width of the car, and the value for `chassis_length` is roughly equal to the length of the car. Other code in MuSHR uses these distinct parameters according to that interpretation as well. The naming problems here need to be addressed in another PR.